### PR TITLE
Ant, gitignore, Travis, Oh My!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+#Binaries
+*.class
+*.jar
+bin/
+dist/
+
+#Eclipse
+.classpath
+.project
+.settings/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+
+install:
+  - ant wpilib-for-ci
+
+script:
+  - ant jar
+
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7
+  - openjdk6
+
+addons:
+  apt:
+    packages:
+      - python3

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# ButtonManager
+# ButtonManager [![Build Status](https://travis-ci.org/Team4761/ButtonManager.svg)](https://travis-ci.org/Team4761/ButtonManager)
 A helpful way to create button listeners for use with FRC Command Based Layout.

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+
+<project name="ButtonManager" basedir="." default="jar">
+
+   <property name="src.dir" value="src"/>
+   <property name="bin.dir" value="bin"/>
+   <property name="dist.dir" value="dist"/>
+
+   <path id="classpath">
+      <fileset dir="${user.home}/wpilib/java/current/lib">
+         <include name="*.jar"/>
+      </fileset>
+   </path>
+
+   <target name="compile" description="Compile source files to .class files">
+      <mkdir dir="${bin.dir}"/>
+      <javac destdir="${bin.dir}" failonerror="true" includeantruntime="false">
+         <src path="${src.dir}"/>
+         <classpath refid="classpath"/>
+      </javac>
+   </target>
+   
+   <target name="jar" depends="compile" description="Make JAR archive">
+      <mkdir dir="${dist.dir}"/>
+      <jar destfile="${dist.dir}/ButtonManager.jar" basedir="${bin.dir}"/>
+   </target>
+
+   <target name="clean" description="Clean output directories">
+      <delete>
+         <fileset dir="${bin.dir}">
+            <include name="**/*.class"/>
+         </fileset>
+         <fileset dir="${dist.dir}">
+            <include name="**/*.jar"/>
+         </fileset>
+      </delete>
+   </target>
+
+   <!-- 
+   Only use on computers that don't have WPILib installed.
+   Bad things _might_ happen but I don't know for sure and don't want to volunteer my installation as a guinea pig.
+   -->
+   <target name="wpilib-for-ci" description="Download and install WPILibJ for use on CI server">
+      <get src="https://gist.githubusercontent.com/simon-andrews/0127707da461e543cb76/raw/dl_wpilibjars.py" dest="dl_wpilibjars.py"/>
+      <exec executable="python3">
+         <arg value="dl_wpilibjars.py"/>
+      </exec>
+      <move file="lib" tofile="${user.home}/wpilib/java/current/lib"/>
+      <delete file="dl_wpilibjars.py"/>
+   </target>
+   
+</project>


### PR DESCRIPTION
Commits should be pretty self-explanatory.

The `wpilib-for-ci` ant task basically downloads a script I wrote that downloads the WPILibJ JARS, then installs them into the same place the Eclipse plugin installs them to. You _probably_ don't want to run this on your own machine.
